### PR TITLE
Include the dataset_description.json as output

### DIFF
--- a/setup-commands/xnat2bids/xnat2bids.py
+++ b/setup-commands/xnat2bids/xnat2bids.py
@@ -189,7 +189,7 @@ def copyScanBidsFiles(destDirBase, bidsScanList):
         for f in scan.sourceFiles:
             shutil.copy(f, destDir)
 
-version = "1.0"
+version = "1.1"
 args = docopt(__doc__, version=version)
 
 inputDir = args['<inputDir>']
@@ -200,6 +200,11 @@ print("Output dir: {}".format(outputDir))
 
 # First check if the input directory is a session directory
 sessionBidsScans = bidsifySession(inputDir)
+
+# BIDS specification 1.2.1: Every BIDS dataset MUST include the dataset_description.json file 
+sessionBidsJsonPath = os.path.join(inputDir, 'RESOURCES', 'BIDS', 'dataset_description.json')
+if os.path.exists(sessionBidsJsonPath):
+    shutil.copy(sessionBidsJsonPath, outputDir)
 
 bidsSubjectMap = {}
 if sessionBidsScans:


### PR DESCRIPTION
As per version 1.2.x BIDS specification states that a BIDS-compliant dataset **MUST** include the compulsory file `dataset_description.json`. See Section 03 (Modality agnostic files) of the BIDS specification.

This small PR ensures that the `xnat2bids.py` script copies the `dataset_description.json` JSON file stored in the BIDS resource into the output directory (if present).

The hereby proposed fix shall permit container-service using the `xnat2bids` setup-command to run up-to-date BIDS apps. Otherwise, BIDS apps might fail running due to invalid BIDS datasets, e.g. see error below running `poldracklab/mriqc:0.15.1` container with current setting: 
> ValueError: 'dataset_description.json' is missing from project root. Every valid BIDS dataset must have this file.

For easy deployment, changes should be propagated in the creation of a new version of the `xnat2bids-setup` docker image at Docker Hub. 