### PR TITLE
Update sample qc assessor command for CS 3.2

### DIFF
--- a/sample-qc-assessor/command.json
+++ b/sample-qc-assessor/command.json
@@ -3,6 +3,7 @@
     "description": "Generate a bogus QC assessor for testing",
     "version": "1.1",
     "schema-version": "1.0",
+    "image": "xnat/generate-test-qc-assessor:latest",
     "type": "docker",
     "command-line": "generate-qc-assessor.py #SESSION_ID# #SESSION_LABEL# #PROJECT# $XNAT_HOST $XNAT_USER $XNAT_PASS /mount out.xml",
     "override-entrypoint": true,
@@ -34,12 +35,14 @@
         {
             "name": "ASSESSOR_XML",
             "description": "QC assessor XML file",
+            "required": true,
             "mount": "mount",
             "path": "out.xml"
         },
         {
             "name": "SUBDIRS",
             "description": "Nested subdirectories",
+            "required": false,
             "mount": "mount",
             "path": "dir0"
         }
@@ -52,24 +55,28 @@
             "external-inputs": [
                 {
                     "name": "session",
-                    "type": "Session"
+                    "type": "Session",
+                    "required": true
                 }
             ],
             "derived-inputs": [
                 {
                     "name": "session_id",
+                    "required": true,
                     "derived-from-wrapper-input": "session",
                     "derived-from-xnat-object-property": "id",
                     "provides-value-for-command-input": "SESSION_ID"
                 },
                 {
                     "name": "session_label",
+                    "required": true,
                     "derived-from-wrapper-input": "session",
                     "derived-from-xnat-object-property": "label",
                     "provides-value-for-command-input": "SESSION_LABEL"
                 },
                 {
                     "name": "project",
+                    "required": true,
                     "derived-from-wrapper-input": "session",
                     "derived-from-xnat-object-property": "project-id",
                     "provides-value-for-command-input": "PROJECT"

--- a/sample-qc-assessor/command.json
+++ b/sample-qc-assessor/command.json
@@ -1,7 +1,7 @@
 {
     "name": "generate-test-qc-assessor",
     "description": "Generate a bogus QC assessor for testing",
-    "version": "1.1",
+    "version": "1.2",
     "schema-version": "1.0",
     "image": "xnat/generate-test-qc-assessor:latest",
     "type": "docker",

--- a/sample-qc-assessor/command.json
+++ b/sample-qc-assessor/command.json
@@ -87,7 +87,8 @@
                     "name": "assessor",
                     "type": "Assessor",
                     "accepts-command-output": "ASSESSOR_XML",
-                    "as-a-child-of": "session"
+                    "as-a-child-of": "session",
+                    "xsi-type": "xnat:qcManualAssessorData"
                 },
                 {
                     "name": "assessor_resource",


### PR DESCRIPTION
Main addition is the xsi type of the output assessor. This is a new field on the command wrapper output handler added in container service 3.2.

Add a few `required=true` fields. This is not the default for this field, but the new values do accurately reflect the need for various inputs.

Added the `image`. This helps when adding the command json directly to the site rather than adding it via pulling the image and reading its labels.