### PR TITLE
Fix sample qc assessor script: Only add scans to assessor if the session had any scans

### DIFF
--- a/sample-qc-assessor/command.json
+++ b/sample-qc-assessor/command.json
@@ -1,7 +1,7 @@
 {
     "name": "generate-test-qc-assessor",
     "description": "Generate a bogus QC assessor for testing",
-    "version": "1.2",
+    "version": "1.3",
     "schema-version": "1.0",
     "image": "xnat/generate-test-qc-assessor:latest",
     "type": "docker",

--- a/sample-qc-assessor/generate-qc-assessor.py
+++ b/sample-qc-assessor/generate-qc-assessor.py
@@ -13,8 +13,8 @@ import requests
 import requests.packages.urllib3
 requests.packages.urllib3.disable_warnings()
 
-versionNumber='1.1'
-dateString='20180724'
+versionNumber='1.3'
+dateString='20220819'
 author='flavin'
 progName=sys.argv[0].split('/')[-1]
 idstring = '$Id: %s,v %s %s %s Exp $'%(progName,versionNumber,dateString,author)
@@ -131,7 +131,14 @@ def main():
         E("rater", name),
         E("stereotacticMarker", random.choice(["0", "1"])),
         E("incidentalFindings", random.choice(["None", "There is something here", "Wowza!", "Nothing", "Nada", "Bupkis", "Meh"])),
-        E("scans",
+        E("comments", random.choice(["Looks good", "All good", "Good", "Bad", "None", "NA"])),
+        E("pass", random.choice(["1", "0", "Yes", "No"])),
+        E("payable", random.choice(["1", "0", "Yes", "No"])),
+        E("rescan", random.choice(["1", "0", "Yes", "No"]))
+    ]
+    
+    if scans:
+        scansListElement = E("scans",
             *[E("scan",
                 E("imageScan_ID", scanId),
                 E("coverage", random.choice(["0", "1", "0.5", "0.25", "0.75", "0.9", "0.1"])),
@@ -139,12 +146,8 @@ def main():
                 E("otherImageArtifacts", random.choice(["None", "NA", "none", "Nothing", "Blurry pixels", "Obscured obscura", "Smudge on the lens", "No", "Nope", "Nothing"])),
                 E("pass", random.choice(["1", "0", "Yes", "No"]))
             ) for scanId in scans]
-        ),
-        E("comments", random.choice(["Looks good", "All good", "Good", "Bad", "None", "NA"])),
-        E("pass", random.choice(["1", "0", "Yes", "No"])),
-        E("payable", random.choice(["1", "0", "Yes", "No"])),
-        E("rescan", random.choice(["1", "0", "Yes", "No"]))
-    ]
+        )
+        assessorElementsList.append(scansListElement)
 
     assessorXML = E('QCManualAssessment', assessorTitleAttributesDict, *assessorElementsList)
 


### PR DESCRIPTION
When running the qc assessor command on a session with no scans, the script had been producing assessors that would fail to upload. But the command would silently ignore this error since the output was no required.

With the recent changes to the command in #9 the assessor output became required and the container runs started failing due to the failed assessor upload.