### PR TITLE
Remove invalid bval/bvec files from fmap directory

### DIFF
--- a/setup-commands/xnat2bids/test_xnat2bids.py
+++ b/setup-commands/xnat2bids/test_xnat2bids.py
@@ -357,6 +357,79 @@ class TestInjectTaskName(unittest.TestCase):
             self.assertEqual(data['TaskName'], task)
 
 
+class TestCleanFmapDir(unittest.TestCase):
+    """Test removal of bval/bvec files from fmap directory."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _import_function(self):
+        """Import cleanFmapDir without triggering docopt."""
+        import types
+        src_path = os.path.join(os.path.dirname(__file__), 'xnat2bids.py')
+        with open(src_path) as f:
+            source = f.read()
+
+        module = types.ModuleType('xnat2bids_test')
+        module.__dict__['os'] = os
+        import glob as glob_mod
+        module.__dict__['glob'] = glob_mod.glob
+
+        lines = source.split('\n')
+        func_lines = []
+        in_func = False
+        for line in lines:
+            if line.startswith('def cleanFmapDir('):
+                in_func = True
+            elif in_func and line and not line[0].isspace() and not line.startswith('#'):
+                break
+            if in_func:
+                func_lines.append(line)
+
+        exec('\n'.join(func_lines), module.__dict__)
+        return module.__dict__['cleanFmapDir']
+
+    def test_removes_bval_bvec_from_fmap(self):
+        """bval and bvec files should be removed from fmap directory."""
+        cleanFmapDir = self._import_function()
+        fmapDir = os.path.join(self.tmpdir, 'fmap')
+        os.makedirs(fmapDir)
+
+        # Create valid fmap files
+        for f in ['sub-01_epi.nii.gz', 'sub-01_epi.json']:
+            open(os.path.join(fmapDir, f), 'w').close()
+        # Create invalid bval/bvec
+        for f in ['sub-01_epi.bval', 'sub-01_epi.bvec']:
+            open(os.path.join(fmapDir, f), 'w').close()
+
+        cleanFmapDir(self.tmpdir)
+
+        remaining = sorted(os.listdir(fmapDir))
+        self.assertEqual(remaining, ['sub-01_epi.json', 'sub-01_epi.nii.gz'])
+
+    def test_no_fmap_dir(self):
+        """Should silently return if no fmap directory exists."""
+        cleanFmapDir = self._import_function()
+        cleanFmapDir(self.tmpdir)  # Should not raise
+
+    def test_fmap_without_bval_bvec(self):
+        """Should leave fmap alone if no bval/bvec present."""
+        cleanFmapDir = self._import_function()
+        fmapDir = os.path.join(self.tmpdir, 'fmap')
+        os.makedirs(fmapDir)
+
+        for f in ['sub-01_epi.nii.gz', 'sub-01_epi.json']:
+            open(os.path.join(fmapDir, f), 'w').close()
+
+        cleanFmapDir(self.tmpdir)
+
+        remaining = sorted(os.listdir(fmapDir))
+        self.assertEqual(remaining, ['sub-01_epi.json', 'sub-01_epi.nii.gz'])
+
+
 class TestSessionDirectoryDetection(unittest.TestCase):
     """Test that generateBidsNameMap correctly parses ses- entity from filenames.
 

--- a/setup-commands/xnat2bids/xnat2bids.py
+++ b/setup-commands/xnat2bids/xnat2bids.py
@@ -218,6 +218,21 @@ def injectTaskName(destDirBase):
         except Exception as e:
             print("WARNING: Could not patch {}: {}".format(func_json, e))
 
+def cleanFmapDir(destDirBase):
+    """Remove bval/bvec files from fmap directory.
+
+    dcm2niix generates bval/bvec for DWI-based EPI fieldmaps but these
+    are not valid BIDS files in fmap/ and cause validation errors.
+    """
+    fmapDir = os.path.join(destDirBase, 'fmap')
+    if not os.path.isdir(fmapDir):
+        return
+
+    for ext in ('*.bval', '*.bvec'):
+        for f in glob(os.path.join(fmapDir, ext)):
+            os.remove(f)
+            print("Removed invalid fmap file: {}".format(os.path.basename(f)))
+
 def injectIntendedFor(destDirBase, subjectDir):
     """Inject IntendedFor into fmap JSON sidecars per BIDS spec.
 
@@ -336,10 +351,12 @@ for bidsSubject in bidsSubjectMap.itervalues():
             copyScanBidsFiles(sessionDir, bidsSession.bidsScans)
             injectIntendedFor(sessionDir, subjectDir)
             injectTaskName(sessionDir)
+            cleanFmapDir(sessionDir)
     else:
         copyScanBidsFiles(subjectDir, bidsSubject.bidsScans)
         injectIntendedFor(subjectDir, subjectDir)
         injectTaskName(subjectDir)
+        cleanFmapDir(subjectDir)
 if sessionBidsScans:
     # Its a single session, copy the dataset_description file
     sessionBidsJsonPath = os.path.join(inputDir, 'RESOURCES', 'BIDS', 'dataset_description.json')


### PR DESCRIPTION
## Summary

- dcm2niix generates `.bval`/`.bvec` files for DWI-based EPI fieldmaps, but these are not valid BIDS files in `fmap/` and cause `NOT_INCLUDED` validation errors
- New `cleanFmapDir()` function removes `fmap/*.bval` and `fmap/*.bvec` after the BIDS tree is assembled
- Called in both the session and non-session copy paths, alongside `injectIntendedFor` and `injectTaskName`

## Test plan

- [x] 3 unit tests added (removes bval/bvec, no-op without fmap dir, no-op without bval/bvec)
- [x] All 21 tests pass
- [x] Built xnat/xnat2bids-setup:1.3 on demo02 with this fix
- [x] Verified on session with DWI EPI fieldmaps — `NOT_INCLUDED` errors resolved